### PR TITLE
Problem 238 - Product of Array Except Self

### DIFF
--- a/238.py
+++ b/238.py
@@ -1,0 +1,25 @@
+class Solution:
+    def productExceptSelf(self, nums: List[int]) -> List[int]:
+        count = len(nums)
+        if count == 0: return []
+        if count == 1: return nums
+
+        prefix = [1] * count
+        running_prefix = 1
+        for i in range(count):
+            prefix[i] = running_prefix
+            running_prefix *= nums[i]
+
+        suffix = [1] * count
+        running_suffix = 1
+        for i in range(count-1, -1, -1):
+            suffix[i] = running_suffix
+            running_suffix *= nums[i]
+
+        answer = [1] * count
+        for i in range(count):
+            answer[i] = prefix[i] * suffix[i]
+
+        return answer
+
+


### PR DESCRIPTION
# Problem 238 - Product of Array Except Self

## Description
Given an integer array nums, return an array answer such that answer[i] is equal to the product of all the elements of nums except nums[i].

## Summarize Key Ideas
- The problem becomes greatly simplified when you look at it from two angles, building a prefix array and a suffix array.
- The prefix array will be responsible for knowing what the product of all numbers up to, but not including i, are.
- The suffix array will be responsible for knowing what the product of all numbers after, but not including i, are.
- You must loop through the given numbers twice in order to build the prefix and suffix array.
- There was one answer where they got away with only two for loops, not sure how they did that though. Didn't dive too deeply into it.