### PR TITLE
Problem 71 - Simplify Path

### DIFF
--- a/71.py
+++ b/71.py
@@ -1,0 +1,12 @@
+class Solution:
+    def simplifyPath(self, path: str) -> str:
+        stack = []
+        for folder in path.split('/'):
+            if folder == '' or folder == '.':
+                continue
+            if folder == '..':
+                if stack:
+                    stack.pop()
+                continue
+            stack.append(folder)
+        return '/' + '/'.join(stack)


### PR DESCRIPTION
# Description

You are given an absolute path for a Unix-style file system, which always begins with a slash '/'. Your task is to transform this absolute path into its simplified canonical path.

The rules of a Unix-style file system are as follows:

A single period '.' represents the current directory.
A double period '..' represents the previous/parent directory.
Multiple consecutive slashes such as '//' and '///' are treated as a single slash '/'.
Any sequence of periods that does not match the rules above should be treated as a valid directory or file name. For example, '...' and '....' are valid directory or file names.
The simplified canonical path should follow these rules:

The path must start with a single slash '/'.
Directories within the path must be separated by exactly one slash '/'.
The path must not end with a slash '/', unless it is the root directory.
The path must not have any single or double periods ('.' and '..') used to denote current or parent directories.
Return the simplified canonical path.

# Key Ideas

- Technique used is a stack
- Implementation requires gathering just the folder names to create the final path, adding them to the stack
- Then just have to adjust for some edge cases such as empty folder names, '.' folder name, and popping the last item from the stack if possible when you come across '..' folder name