### PR TITLE
Problem 236 - Least Common Ancestor of a Binary Tree

### DIFF
--- a/236.py
+++ b/236.py
@@ -7,29 +7,30 @@
 
 class Solution:
     def lowestCommonAncestor(self, root: 'TreeNode', p: 'TreeNode', q: 'TreeNode') -> 'TreeNode':
-        return self.lcaHelper(root, p, q)[2]
+        _, __, lca = self.lcaHelper(root, p, q)
+        return lca
 
 
     def lcaHelper(self, root: 'TreeNode', p: 'TreeNode', q: 'TreeNode') -> (bool, bool, 'TreeNode'):
         '''
-        Returns (has_p, has_q, answer_node)
+        Returns (has_p, has_q, lca)
         '''
-        # queue of children to process
-        # syntax is a bit cleaner this way
-        queue = []
-        if root.left:
-            queue.append(root.left)
-        if root.right:
-            queue.append(root.right)
+        if root == None:
+            return (False, False, None)
+
+        left_has_p, left_has_q, left_lca = self.lcaHelper(root.left, p, q)
+        if left_lca:
+            return (True, True, left_lca)
         
-        has_p = root == p
-        has_q = root == q
-        for child in queue:
-            res = self.lcaHelper(child, p, q)
-            if res[2]:
-                return (True, True, res[2])
-            has_p |= res[0]
-            has_q |= res[1]
-            if has_p and has_q:
-                return (True, True, root)
-        return (has_p, has_q, None)
+        right_has_p, right_has_q, right_lca = self.lcaHelper(root.right, p, q)
+        if right_lca:
+            return (True, True, right_lca)
+
+        cur_has_p = (root == p) or left_has_p or right_has_p
+        cur_has_q = (root == q) or left_has_q or right_has_q
+
+        cur_lca = None
+        if cur_has_p and cur_has_q:
+            cur_lca = root
+       
+        return (cur_has_p, cur_has_q, cur_lca)

--- a/236.py
+++ b/236.py
@@ -7,80 +7,29 @@
 
 class Solution:
     def lowestCommonAncestor(self, root: 'TreeNode', p: 'TreeNode', q: 'TreeNode') -> 'TreeNode':
-        p_path = []
-        q_path = []
-        # depth first search looking for p or q
-        path = []
-        visited = set()
-        node = root
-        while node:
-            if node is p:
-                p_path = [x for x in path]
-                p_path.append(node)
-            if node is q:
-                q_path = [x for x in path]
-                q_path.append(q)
-            if node.left and node.left not in visited:
-                path.append(node)
-                visited.add(node.left)
-                node = node.left
-                continue
-            if node.right and node.right not in visited:
-                path.append(node)
-                visited.add(node.right)
-                node = node.right
-                continue
-            if path:
-                node = path.pop()
-                continue
-            node = None
-
-        # lca will be the last common node in their
-        # paths
-        lca = None
-        for i in range(min(len(p_path), len(q_path))):
-            if p_path[i] is not q_path[i]:
-                break
-            lca = p_path[i]
-        return lca
+        return self.lcaHelper(root, p, q)[2]
 
 
-'''
-Option 1:
-Traverse the tree, adding in parent to each node
-Then trace back up from p to root
-trace from q to root, first node that is in p's path
-is the LCA.
-
-Option 2:
-Depth first search until p and q are found from the root.
-Then you'll have two lists which are the paths of p and q.
-Going backwards from the elements of p's path, check if
-any exist in q's path. First one that does, is the LCA.
-Can use a set to make checking faster
-
-5's path:
-[3, 5]
-1's path:
-[3, 1]
-
-5's path checking
-5 in 1's path: no
-3 is 1's path: yes, that is the LCA
-
-5 and 7
-5's path:
-[3, 5]
-7's path:
-[3, 5, 2, 7]
-
-Option 3:
-Depth first search while tracking the current path.
-When p or q is found, add the path to that node.
-Once both are found, loop through the paths until
-they diverge. The last similar node is the LCA.
-path's should be recorded as a list of nodes.
-
-Option 3 is the way to go.
-
-'''
+    def lcaHelper(self, root: 'TreeNode', p: 'TreeNode', q: 'TreeNode') -> (bool, bool, 'TreeNode'):
+        '''
+        Returns (has_p, has_q, answer_node)
+        '''
+        # queue of children to process
+        # syntax is a bit cleaner this way
+        queue = []
+        if root.left:
+            queue.append(root.left)
+        if root.right:
+            queue.append(root.right)
+        
+        has_p = root == p
+        has_q = root == q
+        for child in queue:
+            res = self.lcaHelper(child, p, q)
+            if res[2]:
+                return (True, True, res[2])
+            has_p |= res[0]
+            has_q |= res[1]
+            if has_p and has_q:
+                return (True, True, root)
+        return (has_p, has_q, None)

--- a/236.py
+++ b/236.py
@@ -1,0 +1,86 @@
+# Definition for a binary tree node.
+# class TreeNode:
+#     def __init__(self, x):
+#         self.val = x
+#         self.left = None
+#         self.right = None
+
+class Solution:
+    def lowestCommonAncestor(self, root: 'TreeNode', p: 'TreeNode', q: 'TreeNode') -> 'TreeNode':
+        p_path = []
+        q_path = []
+        # depth first search looking for p or q
+        path = []
+        visited = set()
+        node = root
+        while node:
+            if node is p:
+                p_path = [x for x in path]
+                p_path.append(node)
+            if node is q:
+                q_path = [x for x in path]
+                q_path.append(q)
+            if node.left and node.left not in visited:
+                path.append(node)
+                visited.add(node.left)
+                node = node.left
+                continue
+            if node.right and node.right not in visited:
+                path.append(node)
+                visited.add(node.right)
+                node = node.right
+                continue
+            if path:
+                node = path.pop()
+                continue
+            node = None
+
+        # lca will be the last common node in their
+        # paths
+        lca = None
+        for i in range(min(len(p_path), len(q_path))):
+            if p_path[i] is not q_path[i]:
+                break
+            lca = p_path[i]
+        return lca
+
+
+'''
+Option 1:
+Traverse the tree, adding in parent to each node
+Then trace back up from p to root
+trace from q to root, first node that is in p's path
+is the LCA.
+
+Option 2:
+Depth first search until p and q are found from the root.
+Then you'll have two lists which are the paths of p and q.
+Going backwards from the elements of p's path, check if
+any exist in q's path. First one that does, is the LCA.
+Can use a set to make checking faster
+
+5's path:
+[3, 5]
+1's path:
+[3, 1]
+
+5's path checking
+5 in 1's path: no
+3 is 1's path: yes, that is the LCA
+
+5 and 7
+5's path:
+[3, 5]
+7's path:
+[3, 5, 2, 7]
+
+Option 3:
+Depth first search while tracking the current path.
+When p or q is found, add the path to that node.
+Once both are found, loop through the paths until
+they diverge. The last similar node is the LCA.
+path's should be recorded as a list of nodes.
+
+Option 3 is the way to go.
+
+'''


### PR DESCRIPTION
# Description

Given a binary tree, find the lowest common ancestor (LCA) of two given nodes in the tree.

According to the [definition of LCA on Wikipedia](https://en.wikipedia.org/wiki/Lowest_common_ancestor): “The lowest common ancestor is defined between two nodes p and q as the lowest node in T that has both p and q as descendants (where we allow a node to be a descendant of itself).”

# Key Ideas

- Depth first search is the technique used
- For the implementation, I used a helper function to will determine if a node has p or q as a child (including itself). Using this, we know that the LCA will be the first node that has both p and q. This is because DFS effectively processes nodes from lowest to highest, and so the first node to have both will be the _lowest_ node to have both. That means that it must be the lowest common ancestor.