### PR TITLE
Problem 56 - Merge Intervals

### DIFF
--- a/56.py
+++ b/56.py
@@ -1,0 +1,35 @@
+# Runtime: O(n log n)
+# Space: O(n)
+# n = number of intervals
+#
+# Time to complete: 18:21
+class Solution:
+    def merge(self, intervals: List[List[int]]) -> List[List[int]]:
+        # in-place quick sort
+        intervals.sort()
+        answer = [intervals[0]]
+        # will this throw an error if intervals.length == 1?
+        for interval in intervals[1:]:
+            last_answer_end = answer[-1][1]
+            interval_start, interval_end = interval
+            if last_answer_end >= interval_start:
+                # only need to update the end
+                answer[-1][1] = max(last_answer_end, interval_end)
+            else:
+                answer.append(interval)
+        return answer
+
+'''
+sorted? not necessarily.
+
+Option 1:
+sort then, merge from start to end
+(modified quick sort)
+
+to merge, once they are sorted,
+elem does not overlap with next (or any other)
+elem overlaps with one OR MORE next elems
+
+should create a new array, and return that
+
+'''


### PR DESCRIPTION
# Description

Given an array of intervals where intervals[i] = [starti, endi], merge all overlapping intervals, and return an array of the non-overlapping intervals that cover all the intervals in the input.

 

Example 1:

Input: intervals = [[1,3],[2,6],[8,10],[15,18]]
Output: [[1,6],[8,10],[15,18]]
Explanation: Since intervals [1,3] and [2,6] overlap, merge them into [1,6].
Example 2:

Input: intervals = [[1,4],[4,5]]
Output: [[1,5]]
Explanation: Intervals [1,4] and [4,5] are considered overlapping.

# Key Ideas

- The techniques used for this are quick sort (already implemented in Python's base language), and a basic for loop.
- For the implementation, if you add in the first element of the sorted list, then we can consider this list as "merged" from the start. From there, we will need to continually add in new intervals and merge them as necessary. Since the intervals are sorted, we only need to compare each interval with the last interval that we added to the answer list.
- There is a potential gotcha here where 1 interval will overlap more than one following intervals. This must be accounted for.