### PR TITLE
Problem 162 - Find Peak Element

### DIFF
--- a/162.py
+++ b/162.py
@@ -1,0 +1,84 @@
+# Runtime: O(log n)
+# Space: O(1)
+#
+# Time to complete: 32:33
+class Solution:
+    def findPeakElement(self, nums: List[int]) -> int:
+        N = len(nums)
+        left, right = 0, len(nums) - 1
+        while left <= right:
+            mid = left + ((right - left) // 2)
+            # guard against out of bounds
+            if mid-1 < 0:
+                mid_left = -float('inf')
+            else:
+                mid_left = nums[mid-1]
+            if mid+1 >= N:
+                mid_right = -float('inf')
+            else:
+                mid_right = nums[mid+1]
+            if mid_left < nums[mid] and nums[mid] > mid_right:
+                return mid
+            if mid_left >= nums[mid]:
+                # there is peak to the left
+                # so go left
+                right = mid - 1
+            else:
+                left = mid + 1
+        # this should never run
+        raise Exception('No peak found')
+
+'''
+Option 1:
+modified binary search
+instead of checking if mid == target
+we will check if mid-1 < mid < mid+1
+and have a way to ensure that mid-1 and mid+1 = inf
+if they are out of bounds
+
+However, the array is not sorted, so why use binary search?
+
+Option 2:
+first number that is not greater than the previous is next to the answer?
+yes.
+
+what would a helper function look like that determines if the answer
+is to the left?
+it would take the value of nums[0], value of nums[n]
+wouldn't work.
+
+[0, 1, 2, 3, 2, 5, 4]
+ ^        ^     ^  ^
+
+0 - 3
+len = 4
+dif = 3
+
+len = 7
+dif = 4
+
+len = 4
+dif = 1
+
+
+Not trying to answer the question is there is no peak within a range.
+Only trying to answer if there is necessarily a peak with a range.
+
+Compare length and differences of values?
+No.
+
+If right is less than left, then there must be a peak
+
+Ok.
+
+Modified binary search:
+a range contains a peak if left > right
+a index is valid if its higher than its neighbors
+This solution should work.
+
+=====
+
+left >= mid:
+then there is a peak between left and mid
+
+'''


### PR DESCRIPTION
# Description

A peak element is an element that is strictly greater than its neighbors.

Given a 0-indexed integer array nums, find a peak element, and return its index. If the array contains multiple peaks, return the index to any of the peaks.

You may imagine that nums[-1] = nums[n] = -∞. In other words, an element is always considered to be strictly greater than a neighbor that is outside the array.

You must write an algorithm that runs in O(log n) time.

# Key Ideas

- Technique: Binary search
- Implementation requires knowing two things in order to modify the binary search.
  1. Whether or not the current value is the target. This is trivial since it just requires checking if the current value is greater than its neighbors. If either of the neighbors are out of bounds, assume -inf. That's a gotcha.
  2. How to determine when to go left or when to go right. Basically, you can think of the array as slopes that are pointing up. From the left side, all the slopes must slopping up to the right, and all the slopes from the right are pointing up to the left. There will be at least one point then, where these slopes meet and that will be the peak. So, in order to determine if a certain range has a peak, you only need to compare the values to see if they follow that order. Left _should be_ smaller than mid, unless there is peak.
  3. There is another gotcha where you are checking the ranges, you must also check for out of bounds numbers, and convert them to -inf.