### PR TITLE
Problem 249 - Group Shifted Strings

### DIFF
--- a/249.py
+++ b/249.py
@@ -1,0 +1,73 @@
+from collections import defaultdict
+from string import ascii_lowercase
+
+# Runtime: O(n)
+# Space: O(n)
+# n = number of characters in strings
+#
+# Time to complete: 35:00
+class Solution:
+    def groupStrings(self, strings: List[str]) -> List[List[str]]:
+        groups = defaultdict(list)
+        for string in strings:
+            key = self.genKey(string)
+            groups[key].append(string)
+        answer = []
+        for key,item in groups.items():
+            answer.append(item)
+        return answer
+    
+    def genKey(self, string: str) -> str:
+        adjustment = ord(string[0])
+        uniform = []
+        for c in string:
+            i = (ord(c) - adjustment) % 26
+            uniform.append(ascii_lowercase[i])
+        return ''.join(uniform)
+
+'''
+Can think of the problem as numbers instead of letters.
+should make things a bit simpler.
+
+abc -> 1,2,3
+
+Need a uniform standard that all string can fit into.
+abc -> 1,2,3
+xyz -> 24,25,26 -> 1,2,3
+
+Since the window can slide, a standard could be:
+differences between characters
+abc -> null, +1, +1
+xyz -> null, +1, +1
+
+But we need to store the standard representation of the strings
+in a way that we can hash it, since we will be using a hashmap
+in order to compare matches in O(1) time.
+
+could make the first letter always a, then adjust the other letters
+to be valid for that string.
+abc -> abc
+xyz -> abc
+fhi -> acd
+
+using that as a key will be easy.
+
+ok, so we need a function to convert a string to the common
+string format
+then we loop through the given strings, and keep placing
+them into a hashmap using that given string as a key.
+can use a defaultdict
+loop through the hashmap to create a list.
+
+a = 97
+f = 97 - 97 = 0 
+
+bcd
+ 98 99 100
+-97 97 97
+=
+1 2 3
+
+How to make sure a-z is only outputted?
+use string.ascii_lowercase
+'''


### PR DESCRIPTION
# Description

Perform the following shift operations on a string:

Right shift: Replace every letter with the successive letter of the English alphabet, where 'z' is replaced by 'a'. For example, "abc" can be right-shifted to "bcd" or "xyz" can be right-shifted to "yza".
Left shift: Replace every letter with the preceding letter of the English alphabet, where 'a' is replaced by 'z'. For example, "bcd" can be left-shifted to "abc" or "yza" can be left-shifted to "xyz".
We can keep shifting the string in both directions to form an endless shifting sequence.

For example, shift "abc" to form the sequence: ... <-> "abc" <-> "bcd" <-> ... <-> "xyz" <-> "yza" <-> .... <-> "zab" <-> "abc" <-> ...
You are given an array of strings strings, group together all strings[i] that belong to the same shifting sequence. You may return the answer in any order.

# Key Ideas

- Technique: hashmap
- Implementation requires just grouping all matching strings into a list within the hash map. The way to tell if two strings match, you must convert them into a standardized format. I chose to just change the first letter to a, and then change all following letters by the same delta.