### PR TITLE
Problem 695 - Max Area of Island

### DIFF
--- a/695.2.py
+++ b/695.2.py
@@ -1,0 +1,66 @@
+from collections import deque
+from typing import Dict, List
+
+# Runtime: O(m * n)
+# Space: O(m * n)
+#
+# Time to complete: 14:04
+class Solution:
+    def maxAreaOfIsland(self, grid: List[List[int]]) -> int:
+        # build adjacency list
+        adj = self.genAdjList(grid)
+        visited = set()
+        max_size = 0
+        # bfs for all nodes
+        for node in adj:
+            size = self.getIslandSize(node, adj, visited)
+            max_size = max(max_size, size)
+        return max_size
+    
+    def genAdjList(self, grid) -> Dict[Tuple[int, int], List[Tuple[int, int]]]:
+        M, N = len(grid[0]), len(grid)
+        adj = {}
+        for y in range(N):
+            for x in range(M):
+                if grid[y][x] == 1:
+                    adj[(y,x)] = []
+        _dirs = [[-1, 0], [1, 0], [0, -1], [0, 1]]
+        for node in adj:
+            for dy,dx in _dirs:
+                ny,nx = node[0] + dy, node[1] + dx
+                if not (0 <= ny < N and 0 <= nx < M):
+                    continue
+                if grid[ny][nx] == 0:
+                    continue
+                adj[node].append((ny,nx))
+        return adj
+    
+    def getIslandSize(self, node, adj, visited) -> int:
+        # bfs on node to get island size
+        q = deque([node])
+        visited.add(node)
+        size = 0
+        while q:
+            curr = q.popleft()
+            size += 1
+            for n in adj[curr]:
+                if n in visited:
+                    continue
+                q.append(n)
+                visited.add(n)
+        return size
+
+
+
+'''
+General graph terms / problem solving.
+High level stuff:
+
+Searching for largest connected component.
+Cells within the grid are nodes.
+
+Convert adj list
+perform bfs for each node in that list
+while tracking max size seen, and keeping a global visited set.
+
+'''


### PR DESCRIPTION
# Notes

I re-did this problem, trying to follow Tim's graph template from the get-go while trying to solve everything else. I also cleaned up my functions.

# Description

You are given an m x n binary matrix grid. An island is a group of 1's (representing land) connected 4-directionally (horizontal or vertical.) You may assume all four edges of the grid are surrounded by water.

The area of an island is the number of cells with a value 1 in the island.

Return the maximum area of an island in grid. If there is no island, return 0.

# Graph Considerations

## What form is the graph given in?

2D matrix of undirected, unweighted graph.

## What are the nodes?

Grid coordinates.

## What is the generalized graph problem?

Largest connected component.

# Key Ideas

## Technique

BFS

## Implementation

- Build an adjacency list.
- Perform BFS on each node in the adjacency list.
- BFS should return the size of the island.
- Use a global visited set so BFS isn't duplicated unnecessarily.